### PR TITLE
Fix for pango error: 'Could not match font'

### DIFF
--- a/src/measure.jl
+++ b/src/measure.jl
@@ -484,8 +484,8 @@ const PANGO_SCALE = 1024.0
 # backend.
 
 # Backend used to match font faces.
-const pango_freetype_fm = ccall(dlsym(libpango, :pango_cairo_font_map_new_for_font_type),
-                                Ptr{Void}, (Int32,), CAIRO_FONT_TYPE_FT)
+const pango_freetype_fm = ccall(dlsym(libpango, :pango_cairo_font_map_get_default),
+                                       Ptr{Void}, ())
 const pango_freetype_ctx = ccall(dlsym(libpango, :pango_font_map_create_context),
                                  Ptr{Void}, (Ptr{Void},), pango_freetype_fm)
 


### PR DESCRIPTION
The current version of Compose:

```
commit 6e861334649c25c849f4828b6fa9a9a2bbd39f9d
Author: Daniel Jones <dcjones@cs.washington.edu>
Date:   Sat Jan 26 17:19:38 2013 -0800

    Fix svglink(nothing) behaviour.
```

gives me the following error on a `draw(..)`

``` jlcon
julia> draw(Gadfly.SVG("ito.svg", 6inch, 4inch), p)

(process:8417): Pango-CRITICAL **: PangoFont *pango_context_load_font(PangoContext *, const PangoFontDescription *): assertion `context != NULL' failed
Could not match font: {"Source Sans Pro,PT Sans,Helvetica Neue,Helvetica,sans 9.000000"}
 in match_font at /Users/aviks/.julia/Compose/src/measure.jl:520
 in pango_set_font at /Users/aviks/.julia/Compose/src/measure.jl:564
 in text_extents at /Users/aviks/.julia/Compose/src/measure.jl:607
 in text_extents at /Users/aviks/.julia/Compose/src/measure.jl:621
 in render at /Users/aviks/.julia/Gadfly/src/guide.jl:261
 in render at /Users/aviks/.julia/Gadfly/src/Gadfly.jl:342
 in draw at /Users/aviks/.julia/Gadfly/src/Gadfly.jl:414
```

This is preceeded by the following assertion failure on loading Compose

``` jlcon
julia> using Gadfly; using Compose

(process:8417): Pango-CRITICAL **: PangoContext *pango_font_map_create_context(PangoFontMap *): assertion `fontmap != NULL' failed
```

Investigating, line 487 fails, returning `null` for pango_freetype_fm

``` julia
const pango_freetype_fm = ccall(dlsym(libpango, :pango_cairo_font_map_new_for_font_type),       
                               Ptr{Void}, (Int32,), CAIRO_FONT_TYPE_FT)
```

The attached changes fixes this issue. Not sure if this is absolutely the right answer, but this change makes the `draw()` function above succeed.  One added benefit might be that the pango docs suggest that the result of `pango_cairo_font_map_get_default()` does not need to be free'd, while the result of `pango_cairo_font_map_new_for_font_type` does need to be freed. 
