### PR TITLE
Add .htm suffix to temp files before passing to browser

### DIFF
--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -361,7 +361,9 @@ function emitsvg(data::String)
     htmlout_path, htmlout = mktemp()
     write(htmlout, Mustache.render(templ, {"svgdata" => data}))
     flush(htmlout)
-    open_browser(htmlout_path)
+    htm_path = htmlout_path * ".htm"
+    mv(htmlout_path, htm_path)
+    open_browser(htm_path)
 end
 
 emitters["image/svg+xml"] = emitsvg


### PR DESCRIPTION
Hi! I’ve started to use Gadfly and am very impressed with the graphics. However, I had difficulties with getting my web browsers to open suffix-less temp files (This is on a Mac). This patch adds a .htm suffix to the temp files before opening them in the browser. 

Technically, this does not guarantee uniqueness as mktemp does, but I’m not sure what a better solution would be with the current file.il calls.
