### PR TITLE
Fix for emitsvg display to a browser window

### DIFF
--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -359,8 +359,11 @@ end
 function emitsvg(data::String)
     templ = readall(joinpath(Pkg.dir("Compose"), "src", "show.html"))
     htmlout_path, htmlout = mktemp()
+    close(htmlout)
+    htmlout_path = htmlout_path * ".html"
+    htmlout = open(htmlout_path, "w")
     write(htmlout, Mustache.render(templ, {"svgdata" => data}))
-    flush(htmlout)
+    close(htmlout)
     open_browser(htmlout_path)
 end
 

--- a/src/show.html
+++ b/src/show.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8">
+  <meta charset="utf-8"/>
   <title>Gadfly Plot</title>
   <style type="text/css">
     .container {


### PR DESCRIPTION
The temp file written in emitsvg currently has no .html extension.  On OS X, the browser then can't open the temp file.  This change adds the .html extension and allows the file to open.

I hope this pull request works.  I use Mercurial and am a bit uncertain how git handles submodules...
