### PR TITLE
Avoid stack-overflow.

### DIFF
--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -92,7 +92,10 @@ typealias Composable Union(Form, Property, Canvas,
 compose(x::Composable) = x
 compose(xs::Tuple) = compose(xs...)
 compose(xs::Array) = compose(xs...)
-compose(x, y, zs...) = compose(compose(compose(x), compose(y)), zs...)
+compose(xs::Union(Tuple,Array), ys::Union(Tuple,Array)) = compose(compose(xs), compose(ys))
+compose(x, xs::Union(Tuple,Array)) = compose(x, compose(xs))
+compose(xs::Union(Tuple,Array), x) = compose(compose(xs), x)
+compose(x, y, z, zs...) = compose(compose(x, y), z, zs...)
 
 # Make nothings go away.
 compose(::Nothing, ::Nothing) = nothing


### PR DESCRIPTION
When trying to compose(a,b), if no such composition is defined then
we should give an error instead of overflowing the stack.

This changes compose(a,b) so that it is not automatically defined for all values of a and b. The previous definition would cause a stack overflow if I accidentally did something like compose(lines(...), lines(...)). The new definition will instead say "ERROR: no method compose(..,..)".
