### PR TITLE
Allow non-strings in labels

### DIFF
--- a/src/form.jl
+++ b/src/form.jl
@@ -458,10 +458,12 @@ function text(x, y, value::String,
 end
 
 
-function text(x, y, value::String)
+function text(x, y, value)
     text(x, y, value, hleft, vbottom)
 end
 
+# Allow converting to string
+text(x, y, v, halign, valign) = text(x, y, string(v), halign, valign)
 
 function boundingbox(form::Text, linewidth::Measure,
                      font::String, fontsize::Measure)

--- a/src/pango.jl
+++ b/src/pango.jl
@@ -120,6 +120,8 @@ function text_extents(font_family::String, size::Measure,
     text_extents(font_family, size/pt, texts...)
 end
 
+# Allow non-string arguments to texts
+text_extents(font_family, size, texts...) = text_extents(font_family, size, [string(t) for t in texts]...)
 
 const pango_attrs = [
     (:PANGO_ATTR_LANGUAGE,        :PangoAttrLanguage),


### PR DESCRIPTION
This is to allow non-`String`s to be used in placing text on the canvas. Passing a `String`, which was required before, will still call exactly the same code as before, but this adds a more general methods that convert their arguments to `String` before calling the original ones.

My main motivation for this was to be able to use a `Float64` column of a `DataFrame` as labels for a Gadfly plot, but I suppose it has other possible uses as well (placing anything convertible to `String` as text, I guess).
