### PR TITLE
Better error messages when Cairo is not installed

### DIFF
--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -56,11 +56,11 @@ catch
     global PNG
     global PS
     global PDF
-    PNG(::String, ::MeasureOrNumber, ::MeasureOrNumber) =
+    PNG(::Union(IO,String), ::MeasureOrNumber, ::MeasureOrNumber) =
         error("Cairo must be installed to use the PNG backend.")
-    PS(::String, ::MeasureOrNumber, ::MeasureOrNumber) =
+    PS(::Union(IO,String), ::MeasureOrNumber, ::MeasureOrNumber) =
         error("Cairo must be installed to use the PS backend.")
-    PDF(::String, ::MeasureOrNumber, ::MeasureOrNumber) =
+    PDF(::Union(IO,String), ::MeasureOrNumber, ::MeasureOrNumber) =
         error("Cairo must be installed to use the PDF backend.")
 end
 


### PR DESCRIPTION
PNG/PS/PDF might be called with an IO argument instead of a filename string.
Make sure the more readable error method is called. Ref
Keno/TerminalExtensions.jl#3
