### PR TITLE
Add more precise check for AMD

### DIFF
--- a/src/svg.jl
+++ b/src/svg.jl
@@ -334,13 +334,13 @@ function finish(img::SVG)
                 """
                 (function (glob, factory) {
                     // AMD support
-                    if (typeof require === "function") {
+                      if (typeof require === "function" && typeof define === "function" && define.amd) {
                         require(["Snap.svg", "Gadfly"], function (Snap, Gadfly) {
                             factory(Snap, Gadfly);
                         });
-                    } else {
-                        factory(glob.Snap, glob.Gadfly);
-                    }
+                      } else {
+                          factory(glob.Snap, glob.Gadfly);
+                      }
                 })(window, function (Snap, Gadfly) {
                     var fig = Snap(\"#$(img.id)\");
                 """)


### PR DESCRIPTION
The require function may exist without AMD, in which case calling it would throw an error. This check should be more reliable.

It'd be great to see a release of this soon so that I can release the next version of Jewel – thanks!
