### PR TITLE
added CAIROSURFACE and helpers to render to a given Cairo surface

### DIFF
--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -21,7 +21,8 @@ export compose, compose!, Context, UnitBox, AbsoluteBoundingBox, Rotation, Paren
        font, fontsize, svgid, svgclass, svgattribute, jsinclude, jscall, Measure,
        inch, mm, cm, pt, px, cx, cy, w, h, hleft, hcenter, hright, vtop, vcenter,
        vbottom, SVG, SVGJS, PGF, PNG, PS, PDF, draw, pad, pad_inner, pad_outer,
-       hstack, vstack, gridstack, LineCapButt, LineCapSquare, LineCapRound
+       hstack, vstack, gridstack, LineCapButt, LineCapSquare, LineCapRound,
+       CAIROSURFACE
 
 abstract Backend
 

--- a/src/cairo_backends.jl
+++ b/src/cairo_backends.jl
@@ -12,6 +12,7 @@ abstract VectorImageBackend <: ImageBackend
 abstract SVGBackend <: VectorImageBackend
 abstract PDFBackend <: VectorImageBackend
 abstract PSBackend  <: VectorImageBackend
+abstract CairoBackend <: VectorImageBackend
 
 type ImagePropertyState
     stroke::Maybe(ColorValue)
@@ -147,11 +148,17 @@ type Image{B <: ImageBackend} <: Backend
         img = Image{B}(IOBuffer(), width, height, emit_on_finish)
         img
     end
+
+    function Image(c::CairoSurface)
+        img = Image{B}(c,CairoContext(c))
+        img
+    end
 end
 
 typealias PNG Image{PNGBackend}
 typealias PDF Image{PDFBackend}
 typealias PS  Image{PSBackend}
+typealias CAIROSURFACE  Image{CairoBackend}
 
 
 # convert compose absolute units (millimeters) to the absolute units used by the
@@ -248,6 +255,8 @@ function newsurface{B}(::Type{B}, out, width, height)
             surface = CairoPDFSurface(out, width, height)
         elseif B == PSBackend
             surface = CairoEPSSurface(out, width, height)
+        elseif B == CairoBackend
+            surface = out
         else
             error("Unkown Cairo backend.")
         end


### PR DESCRIPTION
This should be straightforward: CAIROSURFACE as the output 'device' just reuses a given Cairo surface f.e. from a GtkWindow or similar.

A simple test:

``` julia
using Compose
using Cairo
using Gadfly
p = plot(x=rand(8,1),y=rand(8,1));
co = render(p);
c = Cairo.CairoRGBSurface(400,300);
cr = Cairo.CairoContext(c);
set_source_rgb(cr,1,1,1);
paint(cr);
Compose.draw(CAIROSURFACE(c),co);
write_to_png(c,"cairosurface.png");
```

produces:
![cairosurface](https://cloud.githubusercontent.com/assets/5199059/3672772/a03796bc-1264-11e4-9811-8b85ade94920.png)
