### PR TITLE
Add option to override default resolution for Cairo backends

### DIFF
--- a/src/cairo_backends.jl
+++ b/src/cairo_backends.jl
@@ -761,17 +761,9 @@ function draw(img::Image, prim::LinePrimitive)
     end
 end
 
-
-#function get_layout_size(img::PNG)
-#    width, height = Cairo.get_layout_size(img.ctx)
-#    width / assumed_ppmm, height / assumed_ppmm
-#end
-
-
 function get_layout_size(img::Image)
     width, height = Cairo.get_layout_size(img.ctx)
     width / img.ppmm, height / img.ppmm
-#    25.4 * width / 72, 25.4 * height / 72
 end
 
 


### PR DESCRIPTION
This adds the keyword argument `dpi` to the Cairo backends, for example:

``` julia
draw(PNG("default.png", 1inch, 1inch), p)
draw(PNG("hi_res.png", 1inch, 1inch, dpi=300), p)
```

will result in a 96x96 `default.png` and a 300x300 `hi_res.png`
