### PR TITLE
Fix deprecation warnings for Julia 0.4

### DIFF
--- a/src/container.jl
+++ b/src/container.jl
@@ -407,7 +407,7 @@ end
 # properties, expanding context promises, etc as needed.
 #
 function drawpart(backend::Backend, root_container::Container)
-    S = {(root_container, IdentityTransform(), UnitBox(), root_box(backend))}
+    S = Any[(root_container, IdentityTransform(), UnitBox(), root_box(backend))]
 
     # used to collect property children
     properties = Array(Property, 0)

--- a/src/form.jl
+++ b/src/form.jl
@@ -838,7 +838,7 @@ function absolute_units(p::ArcRelPathOp, t::Transform, units::UnitBox,
               Measure(absolute_units(to.y, t, units, box))))
 end
 
-const path_ops = [
+const path_ops = Dict(
      :M => MoveAbsPathOp,
      :m => MoveRelPathOp,
      :Z => ClosePathOp,
@@ -857,7 +857,7 @@ const path_ops = [
      :t => QuadCurveShortRelPathOp,
      :A => ArcAbsPathOp,
      :a => ArcRelPathOp
-]
+)
 
 
 # A path is an array of symbols, numbers, and measures following SVGs path

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -13,7 +13,7 @@ end
 # Cycle-zip. Zip two or more arrays, cycling the short ones.
 function cyclezip(xs::AbstractArray...)
     if any(map(isempty, xs))
-        return {}
+        return []
     end
     n = maximum([length(x) for x in xs])
     return takestrict(zip([cycle(x) for x in xs]...), n)

--- a/src/pgf_backend.jl
+++ b/src/pgf_backend.jl
@@ -98,7 +98,7 @@ type PGF <: Backend
         img.fontsize = 12.0
         img.indentation = 0
         img.out = out
-        img.color_set = Set{ColorValue}({color("black")})
+        img.color_set = Set{ColorValue}(color("black"))
         img.property_stack = Array(PGFPropertyFrame, 0)
         img.vector_properties = Dict{Type, Union(Nothing, Property)}()
         # img.clippaths = Dict{ClipPrimitive, String}()

--- a/src/svg.jl
+++ b/src/svg.jl
@@ -543,7 +543,7 @@ end
 # Return array of paths to draw with printpath
 # array is formed by splitting by NaN values
 function make_paths(points::Vector{Point})
-    paths = {}
+    paths = []
     nans = find(xy -> isnan(xy[1]) || isnan(xy[2]),
                 [(point.x.abs, point.y.abs) for point in points])
 

--- a/src/table.jl
+++ b/src/table.jl
@@ -44,7 +44,7 @@ type Table <: ContainerPromise
                    y_prop=nothing, x_prop=nothing,
                    aspect_ratio=nothing,
                    units=NilUnitBox(), order=0, withjs=false, withoutjs=false,
-                   fixed_configs={})
+                   fixed_configs=[])
 
         if x_prop != nothing
             @assert length(x_prop) == length(x_focus)
@@ -158,15 +158,15 @@ function realize_brute_force(tbl::Table, drawctx::ParentDrawContext)
     mincolwidths = Array(Float64, n)
 
     # convert tbl.fixed_configs to linear indexing
-    fixed_configs = {
+    fixed_configs = Any[
         Set([(j-1)*m + i for (i, j) in fixed_config])
         for fixed_config in tbl.fixed_configs
-    }
+    ]
 
     # build equilavence classes of configurations basen on fixed_configs
     constrained_cells = Set()
     num_choices = [length(child) for child in tbl.children]
-    num_group_choices = {}
+    num_group_choices = []
     for fixed_config in fixed_configs
         push!(num_group_choices, num_choices[first(fixed_config)])
         for idx in fixed_config


### PR DESCRIPTION
Replace the Dict and Any array syntax changes for 0.4. fixes #101
