### PR TITLE
Use relative paths to get package location

### DIFF
--- a/doc/make.jl
+++ b/doc/make.jl
@@ -1,4 +1,4 @@
 
 using Judo
-Judo.collate("Compose", template=Pkg.dir("Compose", "doc", "template"))
+Judo.collate("Compose", template=joinpath(dirname(@__FILE__), "template"))
 

--- a/src/fontfallback.jl
+++ b/src/fontfallback.jl
@@ -6,7 +6,7 @@ const PANGO_SCALE = 1024.0
 
 # Serialized glyph sizes for commont fonts.
 const glyphsizes = JSON.parse(
-    readall(open(joinpath(Pkg.dir("Compose"), "data", "glyphsize.json"))))
+    readall(open(joinpath(dirname(@__FILE__), "..", "data", "glyphsize.json"))))
 
 
 # It's better to overestimate text extents than to underestimes, since the later

--- a/src/svg.jl
+++ b/src/svg.jl
@@ -1,6 +1,6 @@
 using Compat
 
-const snapsvgjs = Pkg.dir("Compose", "data", "snap.svg-min.js")
+const snapsvgjs = joinpath(dirname(@__FILE__), "..", "data", "snap.svg-min.js")
 
 # Packages can insert extra XML namespaces here to be defined in the output
 # SVG.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,10 @@
 using Compose
 
 #Run the examples
-testdir = joinpath(Pkg.dir("Compose"), "test")
+testdir = dirname(@__FILE__)
 cd(testdir)
 
-exampledir = joinpath(Pkg.dir("Compose"), "examples")
+exampledir = joinpath(dirname(@__FILE__), "..", "examples")
 for ex in readdir(exampledir)
     endswith(ex, ".jl") || continue
     srand(1) #Needed so that SVG uuid is reproducible
@@ -12,7 +12,7 @@ for ex in readdir(exampledir)
 end
 
 #Compare with cached output
-cachedout = joinpath(Pkg.dir("Compose"), "test", "data")
+cachedout = joinpath(dirname(@__FILE__), "data")
 differentfiles = String[]
 for output in readdir(cachedout)
     cached = open(readall, joinpath(cachedout, output))


### PR DESCRIPTION
Using `Pkg.dir("Compose")` to get the path to the Compose installation won't work if Compose is installed outside the standard package location (for example, if it's been installed system-wide for all users). This PR changes instances of `Pkg.dir("Compose")` to use relative paths with `@__FILE__` instead to access other files in the package. See JuliaLang/julia#8679