### PR TITLE
Fixes v0.4 Tuple{A} syntax & updates test results

### DIFF
--- a/src/container.jl
+++ b/src/container.jl
@@ -419,7 +419,7 @@ function drawpart(backend::Backend, root_container::Container)
     properties = Array(Property, 0)
 
     # collect and sort container children
-    container_children = Array((Int, Int, Container), 0)
+    container_children = Array((@compat Tuple{Int, Int, Container}), 0)
 
     while !isempty(S)
         s = pop!(S)

--- a/src/fontfallback.jl
+++ b/src/fontfallback.jl
@@ -105,7 +105,7 @@ function text_extents(font_family::String, size::Measure, texts::String...)
     height = glyphsizes[font_family]["height"]
     widths = glyphsizes[font_family]["widths"]
 
-    extents = Array((Measure, Measure), length(texts))
+    extents = Array((@compat Tuple{Measure, Measure}), length(texts))
     for (i, text) in enumerate(texts)
         width = text_width(widths, text, size/pt)*mm
         extents[i] = (text_extents_scale_x * scale * width,

--- a/src/pango.jl
+++ b/src/pango.jl
@@ -333,7 +333,7 @@ function unpack_pango_attr_list(ptr::Ptr{Void})
     end
 
 
-    attrs = Array((Int, PangoAttr), 0)
+    attrs = Array((@compat Tuple{Int, PangoAttr}), 0)
 
     while attr_it_next() != 0
 

--- a/src/property.jl
+++ b/src/property.jl
@@ -452,7 +452,7 @@ end
 
 immutable JSIncludePrimitive <: PropertyPrimitive
     value::String
-    jsmodule::Union(Nothing, (String, String))
+    jsmodule::Union(Nothing, @compat Tuple{String, String})
 end
 
 typealias JSInclude Property{JSIncludePrimitive}

--- a/src/stack.jl
+++ b/src/stack.jl
@@ -11,7 +11,7 @@
 #  aligned_contexts: One or more canvases accompanied with a vertical alignment
 #                    specifier, giving the vertical positioning of the context.
 #
-function hstack(x0, y0, height, aligned_contexts::(Context, VAlignment)...)
+function hstack(x0, y0, height, aligned_contexts::@compat Tuple{Context, VAlignment} ...)
     if isempty(aligned_contexts)
         return context(x0, y0, 0, height)
     end
@@ -88,7 +88,7 @@ end
 #  aligned_contexts: One or more canvases accompanied with a horizontal alignment
 #                    specifier, giving the horizontal positioning of the context.
 #
-function vstack(x0, y0, width, aligned_contexts::(Context, HAlignment)...)
+function vstack(x0, y0, width, aligned_contexts::@compat Tuple{Context, HAlignment} ...)
 
     if isempty(aligned_contexts)
         return context(x0, y0, width, 0)

--- a/src/svg.jl
+++ b/src/svg.jl
@@ -201,7 +201,7 @@ type SVG <: Backend
     jsheader::Vector{String}
 
     # (Name, binding) pairs of javascript modules the embedded code depends on
-    jsmodules::Vector{(String, String)}
+    jsmodules::Vector{@compat Tuple{String, String}}
 
     # User javascript from JSCall attributes
     scripts::Vector{String}
@@ -246,7 +246,7 @@ type SVG <: Backend
         img.has_current_id = false
         img.id_count = 0
         img.jsheader = String[]
-        img.jsmodules = Array((String, String), 1)
+        img.jsmodules = Array((@compat Tuple{String, String}), 1)
         img.jsmodules[1] = ("Snap.svg", "Snap")
         img.scripts = String[]
         img.withjs = jsmode != :none

--- a/test/data/golden_rect.svg
+++ b/test/data/golden_rect.svg
@@ -8,7 +8,7 @@
      stroke-width="0.3"
      font-size="3.88"
 >
-<g stroke-width="0.2" stroke="#FFFFFF" fill="none" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-1">
+<g stroke-width="0.2" stroke="#FFFFFF" fill="#000000" fill-opacity="0.000" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-1">
   <rect x="0" y="0" width="123.29" height="76.2"/>
   <g fill="#CDD3FF" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-2">
     <rect x="0" y="0" width="123.29" height="76.2"/>

--- a/test/data/linejoins.js
+++ b/test/data/linejoins.js
@@ -9,7 +9,7 @@
      font-size="3.88"
 
      id="fig-7c17cb36d15b4fd9b0c66020318c44ee">
-<g fill="none" stroke-width="2" stroke="#000000" stroke-linejoin="round" id="fig-7c17cb36d15b4fd9b0c66020318c44ee-element-1">
+<g fill="#000000" fill-opacity="0.000" stroke-width="2" stroke="#000000" stroke-linejoin="round" id="fig-7c17cb36d15b4fd9b0c66020318c44ee-element-1">
   <path fill="none" d="M5,5 L 10 10 15 5"/>
   <g stroke-linejoin="miter" id="fig-7c17cb36d15b4fd9b0c66020318c44ee-element-2">
     <path fill="none" d="M5,10 L 10 15 15 10"/>

--- a/test/data/linejoins.svg
+++ b/test/data/linejoins.svg
@@ -8,7 +8,7 @@
      stroke-width="0.3"
      font-size="3.88"
 >
-<g fill="none" stroke-width="2" stroke="#000000" stroke-linejoin="round" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-1">
+<g fill="#000000" fill-opacity="0.000" stroke-width="2" stroke="#000000" stroke-linejoin="round" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-1">
   <path fill="none" d="M5,5 L 10 10 15 5"/>
   <g stroke-linejoin="miter" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-2">
     <path fill="none" d="M5,10 L 10 15 15 10"/>

--- a/test/data/sierpinski.svg
+++ b/test/data/sierpinski.svg
@@ -8,7 +8,7 @@
      stroke-width="0.3"
      font-size="3.88"
 >
-<g stroke="#000000" fill="none" stroke-width="0.1" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-1">
+<g stroke="#000000" fill="#000000" fill-opacity="0.000" stroke-width="0.1" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-1">
   <path d="M101.6,87.99 L 101.2 87.99 101.4 87.64 z"/>
   <path d="M101.2,87.99 L 100.81 87.99 101 87.64 z"/>
   <path d="M101.4,87.64 L 101 87.64 101.2 87.3 z"/>

--- a/test/data/sierpinski_deferred.svg
+++ b/test/data/sierpinski_deferred.svg
@@ -8,7 +8,7 @@
      stroke-width="0.3"
      font-size="3.88"
 >
-<g stroke="#000000" fill="none" stroke-width="0.1" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-1">
+<g stroke="#000000" fill="#000000" fill-opacity="0.000" stroke-width="0.1" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-1">
   <path d="M101.6,87.99 L 101.2 87.99 101.4 87.64 z"/>
   <path d="M101.2,87.99 L 100.81 87.99 101 87.64 z"/>
   <path d="M101.4,87.64 L 101 87.64 101.2 87.3 z"/>


### PR DESCRIPTION
The two issues are independent so I left them as two commits.
The first just updates tuple type args to the new v0.4 format using the `@compat` macro.
The second updates test results for an apparent change from preferring `fill="none"` to `fill="#000000" fill-opacity="0.000"`. The latter is more verbose, and I suppose it's possible it's due to the `Nothing` -> `Void` rename in v0.4, but it doesn't look likely.