### PR TITLE
fix deprecation warning

### DIFF
--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -31,7 +31,8 @@ function isinstalled(pkg, ge=v"0.0.0")
         ver = Pkg.installed(pkg)
         ver == nothing && try
             # Assume the version is new enough if the package is in LOAD_PATH
-            require(pkg)
+            ex = Expr(:import, symbol(pkg))
+            @eval $ex
             return true
         catch
             return false


### PR DESCRIPTION
The deprecation warning suggests using using/import here, but this does not work due to the scope. `include` seems to work just fine, also when running `@spawn Pkg.test("Compose")`