### PR TITLE
Overload showcompact for command-line display of tree structure

### DIFF
--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -9,7 +9,7 @@ using Compat
 import JSON
 
 import Base: length, start, next, done, isempty, getindex, setindex!,
-             display, writemime, convert, zero, isless, max, fill, size, copy,
+             display, writemime, showcompact, convert, zero, isless, max, fill, size, copy,
              min, max, abs, +, -, *, /
 
 export compose, compose!, Context, UnitBox, AbsoluteBoundingBox, Rotation, Mirror,

--- a/src/container.jl
+++ b/src/container.jl
@@ -708,3 +708,32 @@ function introspect(root::Context)
                     (context(order=-2), rectangle(), fill("#333")),
                     lines_ctx, figs)
 end
+
+
+function showcompact(io::IO, ctx::Context)
+    print(io, "Context(")
+    first = true
+    for c in ctx.children
+        first || print(io, ",")
+        first = false
+        showcompact(io, c)
+    end
+    print(io, ")")
+end
+
+function showcompact(io::IO, a::AbstractArray)
+    print(io, "[")
+    first = true
+    for c in a
+        first || print(io, ",")
+        first = false
+        showcompact(io, c)
+    end
+    print(io, "]")
+end
+
+showcompact(io::IO, f::Compose.Form) = print(io, Compose.form_string(f))
+
+showcompact(io::IO, p::Compose.Property) = print(io, Compose.prop_string(p))
+
+showcompact(io::IO, cp::ContainerPromise) = print(io, typeof(cp).name.name)

--- a/src/form.jl
+++ b/src/form.jl
@@ -24,6 +24,7 @@ function draw(backend::Backend, t::Transform, units::UnitBox,
                         for primitive in form.primitives]))
 end
 
+form_string(::Form) = "FORM"  # fallback definition
 
 # Polygon
 # -------
@@ -1049,6 +1050,8 @@ function absolute_units(p::PathPrimitive, t::Transform, units::UnitBox,
                         box::AbsoluteBoundingBox)
     return PathPrimitive([absolute_units(op, t, units, box) for op in p.ops])
 end
+
+
 
 
 # TODO: boundingbox

--- a/src/property.jl
+++ b/src/property.jl
@@ -433,7 +433,13 @@ function svgclass(values::AbstractArray)
     return SVGClass([SVGClassPrimitive(value) for value in values])
 end
 
-prop_string(::SVGClass) = "svgc"
+function prop_string(svgc::SVGClass)
+    if isscalar(svgc)
+        return string("svgc(", svgc.primitives[1].value, ")")
+    else
+        return string("svgc(", svgc.primitives[1].value, "...)")
+    end
+end
 
 # SVGAttribute
 # ------------

--- a/src/property.jl
+++ b/src/property.jl
@@ -63,6 +63,7 @@ function stroke(cs::AbstractArray)
 	return Stroke([StrokePrimitive(c == nothing ? RGBA{Float64}(0, 0, 0, 0) : color(c)) for c in cs])
 end
 
+prop_string(::Stroke) = "s"
 
 # Fill
 # ----
@@ -88,6 +89,7 @@ function fill(cs::AbstractArray)
 	return Fill([FillPrimitive(c == nothing ? RGBA{Float64}(0.0, 0.0, 0.0, 0.0) : color(c)) for c in cs])
 end
 
+prop_string(::Fill) = "f"
 
 
 # StrokeDash
@@ -115,6 +117,8 @@ function absolute_units(primitive::StrokeDashPrimitive, t::Transform,
     return StrokeDashPrimitive([Measure(absolute_units(v, t, units, box))
                                 for v in primitive.value])
 end
+
+prop_string(::StrokeDash) = "sd"
 
 # StrokeLineCap
 # -------------
@@ -150,6 +154,7 @@ function strokelinecap(values::AbstractArray)
     return StrokeLineCap([StrokeLineCapPrimitive(value) for value in values])
 end
 
+prop_string(::StrokeLineCap) = "slc"
 
 # StrokeLineJoin
 # --------------
@@ -184,6 +189,7 @@ function strokelinejoin(values::AbstractArray)
     return StrokeLineJoin([StrokeLineJoinPrimitive(value) for value in values])
 end
 
+prop_string(::StrokeLineJoin) = "slj"
 
 # LineWidth
 # ---------
@@ -214,6 +220,7 @@ function absolute_units(primitive::LineWidthPrimitive, t::Transform,
     return LineWidthPrimitive(Measure(absolute_units(primitive.value, t, units, box)))
 end
 
+prop_string(::LineWidth) = "lw"
 
 # Visible
 # -------
@@ -233,6 +240,8 @@ end
 function visible(values::AbstractArray)
     return Visible([VisiblePrimitive(value) for value in values])
 end
+
+prop_string(::Visible) = "v"
 
 
 # FillOpacity
@@ -262,6 +271,8 @@ function fillopacity(values::AbstractArray)
     return FillOpacity([FillOpacityPrimitive(value) for value in values])
 end
 
+prop_string(::FillOpacity) = "fo"
+
 
 # StrokeOpacity
 # -------------
@@ -290,6 +301,7 @@ function strokeopacity(values::AbstractArray)
     return StrokeOpacity([StrokeOpacityPrimitive(value) for value in values])
 end
 
+prop_string(::StrokeOpacity) = "so"
 
 # Clip
 # ----
@@ -327,6 +339,7 @@ function absolute_units(primitive::ClipPrimitive, t::Transform, units::UnitBox,
                                      for point in primitive.points])
 end
 
+prop_string(::Clip) = "clp"
 
 # Font
 # ----
@@ -347,6 +360,7 @@ function font(families::AbstractArray)
     return Font([FontPrimitive(family) for family in families])
 end
 
+prop_string(::Font) = "fnt"
 
 # FontSize
 # --------
@@ -377,6 +391,7 @@ function absolue_units(primitive::FontSizePrimitive, t::Transform,
     return FontSizePrimitive(Measure(absolute_units(primitive.value, t, units, box)))
 end
 
+prop_string(::FontSize) = "fsz"
 
 # SVGID
 # -----
@@ -397,6 +412,8 @@ function svgid(values::AbstractArray)
     return SVGID([SVGIDPrimitive(value) for value in values])
 end
 
+prop_string(::SVGID) = "svgid"
+
 
 # SVGClass
 # --------
@@ -416,6 +433,7 @@ function svgclass(values::AbstractArray)
     return SVGClass([SVGClassPrimitive(value) for value in values])
 end
 
+prop_string(::SVGClass) = "svgc"
 
 # SVGAttribute
 # ------------
@@ -446,6 +464,7 @@ function svgattribute(attributes::AbstractArray, values::AbstractArray)
             SVGAttributePrimitive(attribute, string(value)))
 end
 
+prop_string(::SVGAttribute) = "svga"
 
 # JSInclude
 # ---------
@@ -465,6 +484,7 @@ end
 # Don't bother with a vectorized version of this. It wouldn't really make #
 # sense.
 
+prop_string(::JSInclude) = "jsip"
 
 # JSCall
 # ------
@@ -541,4 +561,4 @@ function isrepeatable(p::JSCall)
     return true
 end
 
-
+prop_string(::JSCall) = "jsc"

--- a/src/table.jl
+++ b/src/table.jl
@@ -379,4 +379,16 @@ end
     end
 #end
 
-
+function showcompact(io::IO, t::Table)
+    println(io,"$(size(t.children,1))x$(size(t.children,2)) Table:")
+    for i = 1:size(t.children,1)
+        print(io, "  ")
+        first = true
+        for j = 1:size(t.children,2)
+            first || print(io, ",")
+            first = false
+            showcompact(io, t.children[i,j])
+        end
+        println(io)
+    end
+end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1,0 +1,11 @@
+using Colors, Base.Test
+
+tomato_bisque =
+           compose(context(),
+                   (context(), circle(), fill(colorant"bisque")),
+                   (context(), rectangle(), fill(colorant"tomato")))
+
+io = IOBuffer()
+showcompact(io, tomato_bisque)
+str = takebuf_string(io)
+@test str == "Context(Context(f,R),Context(f,C))"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
 using Compose
 
+include("misc.jl")
+
 # Run the examples
 const testdir = dirname(@__FILE__)
 cd(testdir)


### PR DESCRIPTION
Sorry to keep bombing you...more introspection.

The `tomato_bisque` example looks like
```jl
Context(Context(f,R),Context(f,C))
```
and
```jl
p = Gadfly.plot(x=rand(10^6), Gadfly.Geom.histogram(bincount=100));
```
looks like
```jl
julia> showcompact(ctx)
Context(Context(jsip,svgc,3x2 Table:
  [Context(AdhocContainerPromise)],[Context(jsc,Context(Context(Context(Context(svga,lw,Context(s,f,svgc,FORM))),svgc)),Context(Context(fo,svgc,s,Context(jsc,jsc,jsc,f,Context(svgc,f,SP),lw,so,s,R),Context(Context(jsc,jsc,jsc,jsc,jsc,svgc,f,R),Context(jsc,jsc,jsc,f,R)),Context(jsc,jsc,jsc,f,Context(svgc,f,SP),lw,so,s,R))),Context(Context(Context(jsc,jsc,svga,svgc,sd,lw,s,v,L),Context(svgc,sd,lw,s,L)),Context(Context(jsc,jsc,svga,svgc,sd,lw,s,v,L),Context(svgc,sd,lw,s,L)),Context(svga,fo,f,s,svgc,R)))]
  [],[Context(AdhocContainerPromise),Context(AdhocContainerPromise)]
  [],[Context(AdhocContainerPromise),Context(AdhocContainerPromise)]
```

The test I added is quite inadequate. If you like this but are distressed by the poor testing, I could add some `showcompacts` in the Gadfly tests just to make sure it doesn't crash when given different trees.
