### PR TITLE
2x faster makeform

### DIFF
--- a/src/misc.jl
+++ b/src/misc.jl
@@ -20,7 +20,7 @@ function cyclezip(xs::AbstractArray...)
 end
 
 
-# This generates optimized code for a reoccuring pattern in forms and patters
+# This generates optimized code for a reoccuring pattern in forms and patterns
 # that looks like:
 #
 #   return Circle([CirclePrimitive(Point(x, y), x_measure(r))
@@ -45,6 +45,7 @@ macro makeform(args)
         @assert iterator.head == :in
         var = iterator.args[1]
         arr = iterator.args[2]
+        ivar = symbol(string("i_", var))
 
         push!(maxlen_ex.args,
             quote
@@ -53,18 +54,23 @@ macro makeform(args)
                     error("Form cannot be constructed from an empty array")
                 end
             end)
-        push!(type_ex.args, quote $(var) = $(arr)[1] end)
+        push!(type_ex.args, quote
+              $(ivar) = 1
+              $(var) = $(arr)[1]
+              end)
         push!(iter_ex.args, quote
-            $(var) = $(arr)[((i - 1) % length($(arr))) + 1]
+              $(ivar) += 1
+              $(ivar) = $(ivar) > length($(arr)) ? 1 : $(ivar)
+              $(var) = $(arr)[$(ivar)]
         end)
     end
 
-    quote
+    esc(quote
+        $(maxlen_ex)
+
         $(type_ex)
         prim1 = $(constructor)
         T = typeof(prim1)
-
-        $(maxlen_ex)
 
         primitives = Array(T, n)
         primitives[1] = prim1
@@ -73,7 +79,7 @@ macro makeform(args)
             primitives[i] = $(constructor)::T
         end
         Form{T}(primitives)
-    end
+    end)
 end
 
 

--- a/src/patchable.jl
+++ b/src/patchable.jl
@@ -193,9 +193,7 @@ function draw(img::Patchable, prim::LinePrimitive)
 
     paths = make_paths(prim.points)
     if length(paths) > 1
-        addto(Elem(:svg, :g)
-              [Elem(:svg, :path, fill="none", d=svg_fmt_path(path, true))
-               for path in paths])
+        addto(Elem(:svg, :g)[Elem(:svg, :path, fill="none", d=svg_fmt_path(path, true)) for path in paths])
     else
         Elem(:svg, :path, fill="none", d=svg_fmt_path(paths[1], true))
     end
@@ -218,9 +216,7 @@ function draw(img::Patchable, prim::PolygonPrimitive)
 
     paths = make_paths(prim.points)
     if length(paths) > 1
-        addto(Elem(:svg, :g)
-              [Elem(:svg, :path, d=svg_fmt_path(path, true) * " z")
-               for path in paths])
+        addto(Elem(:svg, :g)[Elem(:svg, :path, d=svg_fmt_path(path, true) * " z") for path in paths])
     else
         Elem(:svg, :path, d=svg_fmt_path(paths[1], true) * " z")
     end


### PR DESCRIPTION
`%` (i.e., `rem`) is so slow that it was the main bottleneck in makeform. So I switched it to logic that looks like
```jl
ix = 1
for i = 2:n
    ix += 1
    ix = ix > length(x) ? 1 : ix
    # do something with x[ix]
end
```

Threw in a deprecation-warning removal as a bonus.
