### PR TITLE
Preserve transparency in fill and stroke

### DIFF
--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -45,6 +45,12 @@ function isinstalled(pkg, ge=v"0.0.0")
 end
 
 
+# Allow users to supply strings without deprecation warnings
+parse_colorant(c::Colorant) = c
+parse_colorant(str::AbstractString) = parse(Colorant, str)
+parse_colorant_vec(c...) = to_vec(map(parse_colorant, c)...)
+@noinline to_vec(c...) = [c...]
+
 include("misc.jl")
 include("measure.jl")
 include("list.jl")

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -759,4 +759,6 @@ function _precompile_()
     precompile(Compose.pad_inner, (Compose.Context, Compose.Measure{Compose.MeasureNil, Compose.MeasureNil},))
     precompile(Compose.compose!, (Compose.Context,))
     precompile(Compose.print_pgf_path, (Base.AbstractIOBuffer{Array{UInt8, 1}}, Array{Compose.Point{Compose.Measure{Compose.MeasureNil, Compose.MeasureNil}, Compose.Measure{Compose.MeasureNil, Compose.MeasureNil}}, 1},))
+    precompile(Compose.parse_colorant, (ASCIIString,))
+    precompile(Compose.parse_colorant_vec, (ASCIIString, Vararg{ASCIIString},))
 end

--- a/src/property.jl
+++ b/src/property.jl
@@ -54,13 +54,13 @@ function stroke(c::Nothing)
 end
 
 
-function stroke(c::Union(Color, TransparentColor, String))
-	return Stroke([StrokePrimitive(color(c))])
+function stroke(c::Union(Colorant, String))
+	return Stroke([StrokePrimitive(parse_colorant(c))])
 end
 
 
 function stroke(cs::AbstractArray)
-	return Stroke([StrokePrimitive(c == nothing ? RGBA{Float64}(0, 0, 0, 0) : color(c)) for c in cs])
+	return Stroke([StrokePrimitive(c == nothing ? RGBA{Float64}(0, 0, 0, 0) : parse_colorant(c)) for c in cs])
 end
 
 prop_string(::Stroke) = "s"
@@ -80,13 +80,13 @@ function fill(c::Nothing)
 end
 
 
-function fill(c::Union(Color, TransparentColor, String))
-	return Fill([FillPrimitive(color(c))])
+function fill(c::Union(Colorant, String))
+	return Fill([FillPrimitive(parse_colorant(c))])
 end
 
 
 function fill(cs::AbstractArray)
-	return Fill([FillPrimitive(c == nothing ? RGBA{Float64}(0.0, 0.0, 0.0, 0.0) : color(c)) for c in cs])
+	return Fill([FillPrimitive(c == nothing ? RGBA{Float64}(0.0, 0.0, 0.0, 0.0) : parse_colorant(c)) for c in cs])
 end
 
 prop_string(::Fill) = "f"


### PR DESCRIPTION
I was finding that in Gadfly, `Theme(background_color=c)` wasn't preserving any transparency information in `c`. The root cause was that `color(c)` now strips any transparency (because `Color` does not have transparency), so we need to use a different conversion function if we want to preserve transparency.
