### PR TITLE
Work around julia issue #13375

### DIFF
--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -26,7 +26,7 @@ export compose, compose!, Context, UnitBox, AbsoluteBoundingBox, Rotation, Mirro
 
 abstract Backend
 
-function isinstalled(pkg, ge=v"0.0.0")
+function isinstalled(pkg, ge=v"0.0.0-")
     try
         # Pkg.installed might throw an error,
         # we need to account for it to be able to precompile


### PR DESCRIPTION
Packages get frequently misidentified as `v"0.0.0-"` now. This makes makes them still count by default.