### PR TITLE
Fix breakage on 0.5-dev because of the change in how `a in b` is parsed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,18 @@ language: julia
 os:
     - osx
     - linux
+sudo: required
+dist: trusty
 julia:
     - release
     - nightly
 notifications:
     email: false
+before_install:
+    - if [ `uname` = "Linux" ]; then
+        sudo apt-get update -qq -y;
+        sudo apt-get install libcairo2 libfontconfig1 libpango1.0-0 libpng12-0 libpixman-1-0 gettext;
+      fi
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
     - julia -e 'Pkg.clone(pwd()); Pkg.build("Compose"); Pkg.test("Compose"; coverage=true)'

--- a/examples/sierpinski.jl
+++ b/examples/sierpinski.jl
@@ -1,6 +1,6 @@
 using Compose, Colors
 
-const padding = 0.5mm
+# const padding = 0.5mm
 
 function sierpinski(n::Int)
     if n == 0
@@ -8,9 +8,13 @@ function sierpinski(n::Int)
     else
         t = sierpinski(n - 1)
         compose(context(),
-                (context(0.25w + padding, padding,        0.5w - 2*padding, 0.5h - 2*padding), t),
-                (context(padding,         0.5h + padding, 0.5w - 2*padding, 0.5h - 2*padding), t),
-                (context(0.5w + padding,  0.5h + padding, 0.5w - 2*padding, 0.5h - 2*padding), t))
+                (context(1/4,   0, 1/2, 1/2), t),
+                (context(  0, 1/2, 1/2, 1/2), t),
+                (context(1/2, 1/2, 1/2, 1/2), t))
+        # compose(context(),
+        #         (context(0.25w + padding, padding,        0.5w - 2*padding, 0.5h - 2*padding), t),
+        #         (context(padding,         0.5h + padding, 0.5w - 2*padding, 0.5h - 2*padding), t),
+        #         (context(0.5w + padding,  0.5h + padding, 0.5w - 2*padding, 0.5h - 2*padding), t))
     end
 end
 
@@ -18,7 +22,7 @@ img = SVG("sierpinski.svg", 4inch, 4(√3/2)inch)
 draw(img, compose(sierpinski(2), linewidth(0.1mm), fill(nothing), stroke(colorant"black")))
 
 img = SVG("sierpinski.svg", 4inch, 4(√3/2)inch)
-@time draw(img, compose(sierpinski(11), linewidth(0.1mm), fill(nothing), stroke(colorant"black")))
+@time draw(img, compose(sierpinski(8), linewidth(0.1mm), fill(nothing), stroke(colorant"black")))
 
 #img = SVG("sierpinski.svg", 4inch, 4(√3/2)inch)
 #@profile draw(img, compose(sierpinski(10), linewidth(0.1mm), fill(nothing), stroke(colorant"black")))

--- a/src/cairo_backends.jl
+++ b/src/cairo_backends.jl
@@ -1017,15 +1017,15 @@ function draw_path_op(img::Image, op::CubicCurveShortRelPathOp)
     if ctrl1 === nothing
         ctrl1 = xy
     else
-        ctrl1 = Point(Measure(abs=(2*x1 - ctrl1[1].value) - x1),
-                      Measure(abs=(2*y1 - ctrl1[2].value) - y1))
+        ctrl1 = (Measure(abs=(2*x1 - ctrl1[1].value) - x1),
+                 Measure(abs=(2*y1 - ctrl1[2].value) - y1))
     end
     cx, cy = ctrl1[1].value, ctrl1[2].value
 
     rel_curve_to(img, ctrl1, op.ctrl2, op.to)
     img.last_ctrl2_point =
-        Point(Measure(abs=op.ctrl2[1].value + xy.x.abs),
-              Measure(abs=op.ctrl2[2].value + xy.y.abs))
+        (Measure(abs=op.ctrl2[1].value + xy.x.abs),
+         Measure(abs=op.ctrl2[2].value + xy.y.abs))
 end
 
 
@@ -1035,10 +1035,10 @@ function draw_path_op(img::Image, op::QuadCurveAbsPathOp)
     x2, y2 = op.to[1].value, op.to[2].value
     cx, cy = op.ctrl1[1].value, op.ctrl1[2].value
     curve_to(img,
-             Point(Measure(abs=(x1 + 2*cx)/3),
-                   Measure(abs=(y1 + 2*cy)/3)),
-             Point(Measure(abs=(x2 + 2*cx)/3),
-                   Measure(abs=(y2 + 2*cy)/3)),
+             (Measure(abs=(x1 + 2*cx)/3),
+              Measure(abs=(y1 + 2*cy)/3)),
+             (Measure(abs=(x2 + 2*cx)/3),
+              Measure(abs=(y2 + 2*cy)/3)),
              op.to)
     img.last_ctrl1_point = op.ctrl1
 end
@@ -1050,10 +1050,10 @@ function draw_path_op(img::Image, op::QuadCurveRelPathOp)
     x2, y2 = op.to[1].value, op.to[2].value
     cx, cy = op.ctrl1[1].value, op.ctrl1[2].value
     rel_curve_to(img,
-             Point(Measure(abs=(x1 + 2*cx)/3),
-                   Measure(abs=(y1 + 2*cy)/3)),
-             Point(Measure(abs=(x2 + 2*cx)/3),
-                   Measure(abs=(y2 + 2*cy)/3)),
+                 (Measure(abs=(x1 + 2*cx)/3),
+                  Measure(abs=(y1 + 2*cy)/3)),
+                 (Measure(abs=(x2 + 2*cx)/3),
+                  Measure(abs=(y2 + 2*cy)/3)),
              op.to)
     img.last_ctrl1_point =
         (Measure(abs=op.ctrl1[1].value + xy.x.abs),
@@ -1076,11 +1076,11 @@ function draw_path_op(img::Image, op::QuadCurveShortAbsPathOp)
     cx, cy = ctrl1[1].value, ctrl1[2].value
 
     curve_to(img,
-             Point(Measure(abs=(x1 + 2*cx)/3),
-                   Measure(abs=(y1 + 2*cy)/3)),
-             Point(Measure(abs=(x2 + 2*cx)/3),
-                   Measure(abs=(y2 + 2*cy)/3)),
-             Point(Measure(abs=x2), Measure(abs=y2)))
+             (Measure(abs=(x1 + 2*cx)/3),
+              Measure(abs=(y1 + 2*cy)/3)),
+             (Measure(abs=(x2 + 2*cx)/3),
+              Measure(abs=(y2 + 2*cy)/3)),
+             (Measure(abs=x2), Measure(abs=y2)))
     img.last_ctrl1_point = ctrl1
 end
 
@@ -1094,20 +1094,20 @@ function draw_path_op(img::Image, op::QuadCurveShortRelPathOp)
     if ctrl1 === nothing
         ctrl1 = xy
     else
-        ctrl1 = Point(Measure(abs=(2*x1 - ctrl1[1].value) - x1),
-                      Measure(abs=(2*y1 - ctrl1[2].value) - y1))
+        ctrl1 = (Measure(abs=(2*x1 - ctrl1[1].value) - x1),
+                 Measure(abs=(2*y1 - ctrl1[2].value) - y1))
     end
     cx, cy = ctrl1[1].value, ctrl1[2].value
 
     rel_curve_to(img,
-                 Point(Measure(abs=(x1 + 2*cx)/3),
-                       Measure(abs=(y1 + 2*cy)/3)),
-                 Point(Measure(abs=(x2 + 2*cx)/3),
-                       Measure(abs=(y2 + 2*cy)/3)),
-                 Point(Measure(abs=x2), Measure(abs=y2)))
+                 (Measure(abs=(x1 + 2*cx)/3),
+                  Measure(abs=(y1 + 2*cy)/3)),
+                 (Measure(abs=(x2 + 2*cx)/3),
+                  Measure(abs=(y2 + 2*cy)/3)),
+                 (Measure(abs=x2), Measure(abs=y2)))
     img.last_ctrl1_point =
-        Point(Measure(abs=op.ctrl1[1].value + x1),
-              Measure(abs=op.ctrl1[2].value + y1))
+        (Measure(abs=op.ctrl1[1].value + x1),
+         Measure(abs=op.ctrl1[2].value + y1))
 end
 
 

--- a/src/container.jl
+++ b/src/container.jl
@@ -682,7 +682,7 @@ end
 function showcompact(io::IO, ctx::Context)
     print(io, "Context(")
     first = true
-    for c in ctx.children
+    for c in children(ctx)
         first || print(io, ",")
         first = false
         showcompact(io, c)

--- a/src/form.jl
+++ b/src/form.jl
@@ -58,7 +58,7 @@ function polygon()
 end
 
 
-function polygon{T <: XYTupleOrVec}(points::AbstractArray{T})
+function polygon{T <: XYTupleOrVec}(points::AbstractArray{T}, tag=empty_tag)
     XM, YM = narrow_polygon_point_types(Vector[points])
     if XM == Any
         XM = Length{:cx, Float64}
@@ -69,7 +69,7 @@ function polygon{T <: XYTupleOrVec}(points::AbstractArray{T})
     VecType = Tuple{XM, YM}
 
     return Polygon([PolygonPrimitive(VecType[(x_measure(point[1]), y_measure(point[2]))
-                    for point in points])])
+                    for point in points])], tag)
 end
 
 
@@ -311,9 +311,11 @@ end
 
 
 function ellipse(x, y, x_radius, y_radius, tag=empty_tag)
-    prim = EllipsePrimitive((x, y),
-                            (x_measure(x) + x_measure(x_radius), y),
-                            (x, y_measure(y) + y_measure(y_radius)))
+    xm = x_measure(x)
+    ym = y_measure(y)
+    prim = EllipsePrimitive((xm, ym),
+                            (xm + x_measure(x_radius), ym),
+                            (xm, ym + y_measure(y_radius)))
     return Ellipse{typeof(prim)}([prim], tag)
 end
 
@@ -321,9 +323,9 @@ end
 function ellipse(xs::AbstractArray, ys::AbstractArray,
                  x_radiuses::AbstractArray, y_radiuses::AbstractArray, tag=empty_tag)
     return @makeform (x in xs, y in ys, x_radius in x_radiuses, y_radius in y_radiuses),
-            EllipsePrimitive((x, y),
-                             (x_measure(x) + x_measure(x_radius), y),
-                             (x, y_measure(y) + y_measure(y_radius))) tag
+    EllipsePrimitive((x_measure(x), y_measure(y)),
+                     (x_measure(x) + x_measure(x_radius), y_measure(y)),
+                     (x_measure(x), y_measure(y) + y_measure(y_radius))) tag
 end
 
 
@@ -532,16 +534,20 @@ typealias Curve{P<:CurvePrimitive} Form{P}
 
 function curve(anchor0::XYTupleOrVec, ctrl0::XYTupleOrVec,
                ctrl1::XYTupleOrVec, anchor1::XYTupleOrVec, tag=empty_tag)
-    return Curve([CurvePrimitive(convert(Vec, anchor0), convert(Vec, ctrl0),
-                                 convert(Vec, ctrl1), convert(Vec, anchor1))], tag)
+    return Curve([CurvePrimitive((x_measure(anchor0[1]), y_measure(anchor0[2])),
+                                 (x_measure(ctrl0[1]), y_measure(ctrl0[2])),
+                                 (x_measure(ctrl1[1]), y_measure(ctrl1[2])),
+                                 (x_measure(anchor1[1]), y_measure(anchor1[2])))], tag)
 end
 
 
 function curve(anchor0s::AbstractArray, ctrl0s::AbstractArray,
                ctrl1s::AbstractArray, anchor1s::AbstractArray, tag=empty_tag)
     return @makeform (anchor0 in anchor0s, ctrl0 in ctrl0s, ctrl1 in ctrl1s, anchor1 in anchor1s),
-            CurvePrimitive(convert(Vec, anchor0), convert(Vec, ctrl0),
-                           convert(Vec, ctrl1), convert(Vec, anchor1)) tag
+    CurvePrimitive((x_measure(anchor0[1]), y_measure(anchor0[2])),
+                   (x_measure(ctrl0[1]), y_measure(ctrl0[2])),
+                   (x_measure(ctrl1[1]), y_measure(ctrl1[2])),
+                   (x_measure(anchor1[1]), y_measure(anchor1[2]))) tag
 end
 
 

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -46,13 +46,13 @@ end
 # This generates optimized code for a reoccuring pattern in forms and patterns
 # that looks like:
 #
-#   return Circle([CirclePrimitive(Point(x, y), x_measure(r))
+#   return Circle([CirclePrimitive((x, y), x_measure(r))
 #                  for (x, y, r) in cyclezip(xs, ys, rs)])
 #
 # This macro does the equivalent with
 #
 #   return @makeform (x in xs, y in ys, r in rs),
-#                    CirclePrimitive(Point(x, y), x_measure(r)))
+#                    CirclePrimitive((x, y), x_measure(r)))
 #
 # but much more efficiently.
 macro makeform(args...)

--- a/test/data/golden_rect.svg
+++ b/test/data/golden_rect.svg
@@ -8,25 +8,25 @@
      stroke-width="0.3"
      font-size="3.88"
 >
-<g stroke-width="0.2" stroke="#FFFFFF" fill="#000000" fill-opacity="0.000" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-1">
+<g stroke-width="0.2" stroke="#FFFFFF" fill="#000000" fill-opacity="0.000" id="e6c61b5b-1">
   <rect x="0" y="0" width="123.29" height="76.2"/>
-  <g fill="#CDD3FF" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-2">
+  <g fill="#CDD3FF" id="e6c61b5b-2">
     <rect x="0" y="0" width="123.29" height="76.2"/>
-    <g fill="#FFC3FF" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-3">
+    <g fill="#FFC3FF" id="e6c61b5b-3">
       <rect x="0" y="0" width="123.29" height="76.2"/>
-      <g fill="#FFB3FF" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-4">
+      <g fill="#FFB3FF" id="e6c61b5b-4">
         <rect x="0" y="0" width="123.29" height="76.2"/>
-        <g fill="#FFA5FF" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-5">
+        <g fill="#FFA5FF" id="e6c61b5b-5">
           <rect x="0" y="0" width="123.29" height="76.2"/>
-          <g fill="#FF9CF3" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-6">
+          <g fill="#FF9CF3" id="e6c61b5b-6">
             <rect x="0" y="0" width="123.29" height="76.2"/>
-            <g fill="#FF9BCC" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-7">
+            <g fill="#FF9BCC" id="e6c61b5b-7">
               <rect x="0" y="0" width="123.29" height="76.2"/>
-              <g fill="#FFA1A6" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-8">
+              <g fill="#FFA1A6" id="e6c61b5b-8">
                 <rect x="0" y="0" width="123.29" height="76.2"/>
-                <g fill="#FFAD84" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-9">
+                <g fill="#FFAD84" id="e6c61b5b-9">
                   <rect x="0" y="0" width="123.29" height="76.2"/>
-                  <g fill="#FFBC65" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-10">
+                  <g fill="#FFBC65" id="e6c61b5b-10">
                     <rect x="0" y="0" width="123.29" height="76.2"/>
                   </g>
                 </g>

--- a/test/data/linecaps.svg
+++ b/test/data/linecaps.svg
@@ -8,11 +8,11 @@
      stroke-width="0.3"
      font-size="3.88"
 >
-<g stroke-width="2" stroke="#000000" stroke-linecap="butt" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-1">
+<g stroke-width="2" stroke="#000000" stroke-linecap="butt" id="e6c61b5b-1">
   <path fill="none" d="M5,5 L 15 5"/>
-  <g stroke-linecap="square" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-2">
+  <g stroke-linecap="square" id="e6c61b5b-2">
     <path fill="none" d="M5,10 L 15 10"/>
-    <g stroke-linecap="round" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-3">
+    <g stroke-linecap="round" id="e6c61b5b-3">
       <path fill="none" d="M5,15 L 15 15"/>
     </g>
   </g>

--- a/test/data/linejoins.js
+++ b/test/data/linejoins.js
@@ -8,12 +8,12 @@
      stroke-width="0.3"
      font-size="3.88"
 
-     id="fig-7c17cb36d15b4fd9b0c66020318c44ee">
-<g fill="#000000" fill-opacity="0.000" stroke-width="2" stroke="#000000" stroke-linejoin="round" id="fig-7c17cb36d15b4fd9b0c66020318c44ee-element-1">
+     id="7c17cb36">
+<g fill="#000000" fill-opacity="0.000" stroke-width="2" stroke="#000000" stroke-linejoin="round" id="7c17cb36-1">
   <path fill="none" d="M5,5 L 10 10 15 5"/>
-  <g stroke-linejoin="miter" id="fig-7c17cb36d15b4fd9b0c66020318c44ee-element-2">
+  <g stroke-linejoin="miter" id="7c17cb36-2">
     <path fill="none" d="M5,10 L 10 15 15 10"/>
-    <g stroke-linejoin="bevel" id="fig-7c17cb36d15b4fd9b0c66020318c44ee-element-3">
+    <g stroke-linejoin="bevel" id="7c17cb36-3">
       <path fill="none" d="M5,15 L 10 20 15 15"/>
     </g>
   </g>

--- a/test/data/linejoins.svg
+++ b/test/data/linejoins.svg
@@ -8,11 +8,11 @@
      stroke-width="0.3"
      font-size="3.88"
 >
-<g fill="#000000" fill-opacity="0.000" stroke-width="2" stroke="#000000" stroke-linejoin="round" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-1">
+<g fill="#000000" fill-opacity="0.000" stroke-width="2" stroke="#000000" stroke-linejoin="round" id="e6c61b5b-1">
   <path fill="none" d="M5,5 L 10 10 15 5"/>
-  <g stroke-linejoin="miter" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-2">
+  <g stroke-linejoin="miter" id="e6c61b5b-2">
     <path fill="none" d="M5,10 L 10 15 15 10"/>
-    <g stroke-linejoin="bevel" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-3">
+    <g stroke-linejoin="bevel" id="e6c61b5b-3">
       <path fill="none" d="M5,15 L 10 20 15 15"/>
     </g>
   </g>

--- a/test/data/sierpinski.svg
+++ b/test/data/sierpinski.svg
@@ -8,7 +8,7 @@
      stroke-width="0.3"
      font-size="3.88"
 >
-<g stroke="#000000" fill="#000000" fill-opacity="0.000" stroke-width="0.1" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-1">
+<g stroke="#000000" fill="#000000" fill-opacity="0.000" stroke-width="0.1" id="7c17cb36-1">
   <path d="M101.6,87.99 L 101.2 87.99 101.4 87.64 z"/>
   <path d="M101.2,87.99 L 100.81 87.99 101 87.64 z"/>
   <path d="M101.4,87.64 L 101 87.64 101.2 87.3 z"/>

--- a/test/data/sierpinski_deferred.svg
+++ b/test/data/sierpinski_deferred.svg
@@ -8,7 +8,7 @@
      stroke-width="0.3"
      font-size="3.88"
 >
-<g stroke="#000000" fill="#000000" fill-opacity="0.000" stroke-width="0.1" id="fig-e6c61b5b8b554cb79b7700d905a3c167-element-1">
+<g stroke="#000000" fill="#000000" fill-opacity="0.000" stroke-width="0.1" id="e6c61b5b-1">
   <path d="M101.6,87.99 L 101.2 87.99 101.4 87.64 z"/>
   <path d="M101.2,87.99 L 100.81 87.99 101 87.64 z"/>
   <path d="M101.4,87.64 L 101 87.64 101.2 87.3 z"/>

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1,6 +1,4 @@
-
 using Colors, Base.Test
-import Compose: Point
 
 # showcompact
 tomato_bisque =
@@ -11,11 +9,11 @@ tomato_bisque =
 io = IOBuffer()
 showcompact(io, tomato_bisque)
 str = takebuf_string(io)
-@test str == "Context(Context(f,R),Context(f,C))"
+@test str == "Context(Context(R,f),Context(C,f))"
 
 # Tagging
 function points(xa, ya)
-    [Point(x,y) for (x,y) in zip(xa,ya)]
+    [(x, y) for (x, y) in zip(xa, ya)]
 end
 
 pnts = points(rand(5), rand(5))


### PR DESCRIPTION
I guess I could figure out which commit/PR introduces this change and enable this only on the necessary versions but this should be good enough and it shouldn't be performance critical anyway....

(Expression patter matching could probably help with this...)
