### PR TITLE
Add Immerse backend and tests

### DIFF
--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -154,6 +154,7 @@ default_fill_color = colorant"black"
 # Use cairo for the PNG, PS, PDF if it's installed.
 if isinstalled("Cairo")
     include("cairo_backends.jl")
+    include("immerse_backend.jl")
 else
     global PNG
     global PS

--- a/src/cairo_backends.jl
+++ b/src/cairo_backends.jl
@@ -205,6 +205,8 @@ function absolute_native_units{B}(img::Image{B}, u::Float64)
     img.ppmm * u
 end
 
+surface(img::Image) = img.surface
+
 function Measures.width(img::Image)
     (Cairo.width(img.surface) / img.ppmm) * mm
 end
@@ -1215,6 +1217,3 @@ function draw(img::Image, batch::FormBatch)
     end
     Cairo.set_antialias(img.ctx, Cairo.ANTIALIAS_DEFAULT)
 end
-
-
-

--- a/src/container.jl
+++ b/src/container.jl
@@ -431,6 +431,7 @@ function draw(backend::Backend, root_container::Container)
     finish(backend)
 end
 
+register_coords(backend::Backend, box, units, transform, form) = nothing
 
 immutable DrawState
     pop_poperty::Bool
@@ -513,6 +514,7 @@ function drawpart(backend::Backend, container::Container,
 
         child = ctx.property_children
         while !isa(child, ListNull)
+            register_coords(backend, box, units, transform, child.head)
             push!(properties, resolve(parent_box, units, parent_transform, child.head))
             child = child.tail
         end
@@ -533,6 +535,7 @@ function drawpart(backend::Backend, container::Container,
     trybatch = canbatch(backend)
     child = ctx.form_children
     while !isa(child, ListNull)
+        register_coords(backend, box, units, transform, child.head)
         form = resolve(box, units, transform, child.head)
         if isempty(form.primitives)
             child = child.tail

--- a/src/immerse_backend.jl
+++ b/src/immerse_backend.jl
@@ -1,0 +1,51 @@
+# The Immerse backend
+# To the Cairo backend, this adds just one feature: keeping track of
+# the rendered coordinates of tagged objects and svgclass("plotpanel")
+# objects
+
+export ImmerseBackend
+
+type ImmerseBackend <: Backend
+    cb::CAIROSURFACE
+    coords::Dict{Symbol,Any}
+    panelcoords::Vector
+end
+
+function ImmerseBackend(c::CairoSurface)
+    cb = CAIROSURFACE(c)
+    ImmerseBackend(cb, Dict{Symbol,Any}(), Any[])
+end
+
+root_box(backend::ImmerseBackend) = root_box(backend.cb)
+
+push_property_frame(backend::ImmerseBackend, properties) = push_property_frame(backend.cb, properties)
+
+pop_property_frame(backend::ImmerseBackend) = pop_property_frame(backend.cb)
+
+function draw(backend::ImmerseBackend, root_container::Container)
+    empty!(backend.coords)
+    empty!(backend.panelcoords)
+    drawpart(backend, root_container, IdentityTransform(), UnitBox(), root_box(backend))
+    finish(backend)
+end
+
+function register_coords(backend::ImmerseBackend, box, units, transform, form::Form)
+    if form.tag != empty_tag
+        backend.coords[form.tag] = (box, units, transform)
+    end
+    nothing
+end
+
+function register_coords(backend::ImmerseBackend, box, units, transform, property::SVGClass)
+    if length(property.primitives) == 1 && property.primitives[1].value == "plotpanel"
+        push!(backend.panelcoords, (box, units, transform))
+    end
+    nothing
+end
+
+draw(backend::ImmerseBackend, form::Form) = draw(backend.cb, form)
+
+finish(backend::ImmerseBackend) = finish(backend.cb)
+
+iswithjs(::ImmerseBackend) = false
+iswithousjs(::ImmerseBackend) = true

--- a/src/immerse_backend.jl
+++ b/src/immerse_backend.jl
@@ -43,6 +43,12 @@ function register_coords(backend::ImmerseBackend, box, units, transform, propert
     nothing
 end
 
+absolute_native_units(backend::ImmerseBackend, u::Float64) = absolute_native_units(backend.cb, u)
+absolute_native_units(backend::ImmerseBackend, l::Length{:mm}) = absolute_native_units(backend.cb, l.value)
+absolute_native_units(backend::ImmerseBackend, l::Tuple{Length{:mm},Length{:mm}}) = (absolute_native_units(backend.cb, l[1].value), absolute_native_units(backend.cb, l[2].value))
+
+surface(backend::ImmerseBackend) = surface(backend.cb)
+
 draw(backend::ImmerseBackend, form::Form) = draw(backend.cb, form)
 
 finish(backend::ImmerseBackend) = finish(backend.cb)

--- a/test/compare_examples.jl
+++ b/test/compare_examples.jl
@@ -1,0 +1,39 @@
+# Compare with cached output
+cachedout = joinpath(testdir, "data")
+differentfiles = AbstractString[]
+const creator_producer = r"(Creator|Producer)"
+for output in readdir(cachedout)
+    cached = open(readlines, joinpath(cachedout, output))
+    genned = open(readlines, joinpath(testdir, output))
+    same = (n=length(cached)) == length(genned)
+    if same
+        lsame = Bool[cached[i] == genned[i] for i = 1:n]
+        if !all(lsame)
+            for idx in find(!lsame)
+                # Don't worry about lines that are due to
+                # Creator/Producer (e.g., Cairo versions)
+                if !isempty(search(cached[idx], creator_producer))
+                    lsame[idx] = true
+                end
+            end
+        end
+        same = same & all(lsame)
+    end
+    if !same
+        push!(differentfiles, output)
+    else #Delete generated file
+        rm(joinpath(testdir, output))
+    end
+end
+
+#Print out which files differ and their diffs
+if length(differentfiles)>0
+    #Capture diffs
+    diffs = map(
+        output -> output * ":\n" *
+            readall(ignorestatus(`diff $(joinpath(cachedout, output)) $(joinpath(testdir, output))`)) *
+            "\n\n",
+        differentfiles)
+    error(string("Generated output differs from cached test output:\n",
+        join(differentfiles, "\n"), "\n\n", join(diffs, "\n")))
+end

--- a/test/immerse.jl
+++ b/test/immerse.jl
@@ -56,3 +56,22 @@ has_tag(obj, tag) = false
 has_tag(obj)      = false
 
 @test find_tagged(ctx)[:rect] == ctx
+
+### Coordinate computations
+function absolute_to_data(x, y, transform, unit_box, parent_box)
+    xt, yt = invert_transform(transform, x, y)
+    (unit_box.x0 + unit_box.width *(xt-parent_box.x0[1])/Measures.width(parent_box),
+     unit_box.y0 + unit_box.height*(yt-parent_box.x0[2])/Measures.height(parent_box))
+end
+
+invert_transform(::Compose.IdentityTransform, x, y) = x, y
+
+function invert_transform(t::Compose.MatrixTransform, x, y)
+    @assert t.M[3,1] == t.M[3,2] == 0
+    xyt = t.M\[x, y, 1.0]
+    xyt[1], xyt[2]
+end
+
+box, units, transform = be.coords[:rect]
+xd, yd = absolute_to_data(0.5mm, 0.5mm, transform, units, box)
+@test_approx_eq_eps xd 0.1417 0.0001

--- a/test/immerse.jl
+++ b/test/immerse.jl
@@ -1,0 +1,58 @@
+# These tests are designed to ensure that Immerse.jl works. If you
+# need to edit these tests to make them pass, that's fine, but please
+# submit the corresponding fix to Immerse.
+
+using Compose, Base.Test
+import Cairo
+
+### The Immerse backend
+srf = Cairo.CairoImageSurface(10, 10, Cairo.FORMAT_RGB24)
+ctx = compose(compose(context(), rectangle(0.0w, 0.0h, 0.8w, 0.7h, :rect)), fill("tomato"))
+be = Compose.ImmerseBackend(srf)
+draw(be, ctx)
+@test be.coords[:rect][2] == Compose.UnitBox{Float64,Float64,Float64,Float64}(0.0,0.0,1.0,1.0)
+
+### Finding tagged objects
+typealias ContainersWithChildren Union{Context,Compose.Table}
+typealias Iterables Union{ContainersWithChildren, AbstractArray}
+
+iterable(ctx::ContainersWithChildren) = ctx.children
+iterable(a::AbstractArray) = a
+
+function find_tagged(root)
+    handles = Dict{Symbol,Context}()
+    find_tagged!(handles, root)
+end
+
+function find_tagged!(handles, obj::Iterables)
+    for item in iterable(obj)
+        if has_tag(item)
+            handles[item.tag] = obj
+        else
+            find_tagged!(handles, item)
+        end
+    end
+    handles
+end
+
+function find_tagged!(handles, obj::Context)
+    for item in obj.form_children
+        if has_tag(item)
+            handles[item.tag] = obj
+        end
+    end
+    for item in obj.container_children
+        find_tagged!(handles, item)
+    end
+    handles
+end
+
+find_tagged!(handles, obj) = obj
+
+has_tag(form::Compose.Form, tag) = form.tag == tag
+has_tag(form::Compose.Form)      = form.tag != Compose.empty_tag
+
+has_tag(obj, tag) = false
+has_tag(obj)      = false
+
+@test find_tagged(ctx)[:rect] == ctx

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,42 +14,6 @@ for ex in readdir(exampledir)
     include(joinpath(exampledir, ex))
 end
 
-# Compare with cached output
-cachedout = joinpath(testdir, "data")
-differentfiles = AbstractString[]
-const creator_producer = r"(Creator|Producer)"
-for output in readdir(cachedout)
-    cached = open(readlines, joinpath(cachedout, output))
-    genned = open(readlines, joinpath(testdir, output))
-    same = (n=length(cached)) == length(genned)
-    if same
-        lsame = Bool[cached[i] == genned[i] for i = 1:n]
-        if !all(lsame)
-            for idx in find(!lsame)
-                # Don't worry about lines that are due to
-                # Creator/Producer (e.g., Cairo versions)
-                if !isempty(search(cached[idx], creator_producer))
-                    lsame[idx] = true
-                end
-            end
-        end
-        same = same & all(lsame)
-    end
-    if !same
-        push!(differentfiles, output)
-    else #Delete generated file
-        rm(joinpath(testdir, output))
-    end
-end
-
-#Print out which files differ and their diffs
-if length(differentfiles)>0
-    #Capture diffs
-    diffs = map(
-        output -> output * ":\n" *
-            readall(ignorestatus(`diff $(joinpath(cachedout, output)) $(joinpath(testdir, output))`)) *
-            "\n\n",
-        differentfiles)
-    error(string("Generated output differs from cached test output:\n",
-        join(differentfiles, "\n"), "\n\n", join(diffs, "\n")))
+if !haskey(ENV, "TRAVIS")
+    include("compare_examples.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Compose
 
 include("misc.jl")
+include("immerse.jl")
 
 # Run the examples
 const testdir = dirname(@__FILE__)


### PR DESCRIPTION
This adds an official backend for Immerse. This eliminates the need to copy `drawpart` into Immerse, see https://github.com/JuliaGraphics/Immerse.jl/pull/47. It also adds tests for at least some of the functionality that Immerse depends on; it probably isn't comprehensive, but it's a step in the right direction.

If you like some of the functionality in the Immerse tests, of course feel free to cop it. (In general you should feel free to steal anything you want from Immerse/src/compose.jl.) But I didn't want to "pollute" Compose with functionality that others won't need, so I put everything in the test script.

Finally, I modified the tests so that Travis doesn't always fail. If you don't like this, I'll revert this part.

I didn't need to change Gadfly at all; the only part I thought about changing were [these lines](https://github.com/dcjones/Gadfly.jl/blob/fcb249691700cdfde56184049060258ca8758c6d/src/coord.jl#L230-L233) because formerly I had been using `aes.xminview` etc for zooming. Now it seems that `xminview` can only expand the view, not contract it. I switched to using `coord.xmin`, and now it's working again, but if you think `xminview` really should specify the view (or is misleadingly named) perhaps there are additional changes that should be made.