### PR TITLE
Require Fontconfig when using Cairo-based backends

### DIFF
--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -154,8 +154,9 @@ default_fill_color = colorant"black"
 # Use cairo for the PNG, PS, PDF if it's installed.
 macro missing_cairo_error(backend)
     msg1 = """
-    Cairo is necessary for the $(backend) backend. Run:
+    Cairo and Fontconfig are necessary for the $(backend) backend. Run:
       Pkg.add("Cairo")
+      Pkg.add("Fontconfig")
     """
     msg2 = if VERSION >= v"0.4.0-dev+6521"
         """

--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -152,6 +152,24 @@ default_fill_color = colorant"black"
 
 
 # Use cairo for the PNG, PS, PDF if it's installed.
+macro missing_cairo_error(backend)
+    msg1 = """
+    Cairo is necessary for the $(backend) backend. Run:
+      Pkg.add("Cairo")
+    """
+    msg2 = if VERSION >= v"0.4.0-dev+6521"
+        """
+        You also have to delete $(joinpath(Base.LOAD_CACHE_PATH[1], "Compose.ji"))
+        and restart your REPL session afterwards.
+        """
+    else
+        """
+        You also have to restart your REPL session afterwards.
+        """
+    end
+    string(msg1, msg2)
+end
+
 if isinstalled("Cairo")
     include("cairo_backends.jl")
 else
@@ -159,16 +177,9 @@ else
     global PS
     global PDF
 
-    msg1 = "Install Cairo.jl to use the "
-    msg2 = " backend."
-    if VERSION >= v"0.4.0-dev+6521"
-        msg2 = string(msg2,
-            " You may need to delete $(joinpath(Base.LOAD_CACHE_PATH[1], "Compose.ji")) afterwards.")
-    end
-
-    PNG(args...) = error(string(msg1, "PNG", msg2))
-    PS(args...) = error(string(msg1, "PS", msg2))
-    PDF(args...) = error(string(msg1, "PDF", msg2))
+    PNG(args...) = error(@missing_cairo_error "PNG")
+    PS(args...) = error(@missing_cairo_error "PS")
+    PDF(args...) = error(@missing_cairo_error "PDF")
 end
 include("svg.jl")
 include("pgf_backend.jl")


### PR DESCRIPTION
As was discussed in dcjones/Gadfly.jl#688, you need Fontconfig with Cairo-based backends to have correct text sizes. So this makes Fontconfig mandatory and clarifies the error message you get. I.e. we go from this
```
julia> PNG()
ERROR: Install Cairo.jl to use the PNG backend. You may need to delete /home/morten/.julia/lib/v0.4/Compose.ji afterwards.
```
to this
```
julia> PNG()
ERROR: Cairo and Fontconfig are necessary for the PNG backend. Run:
  Pkg.add("Cairo")
  Pkg.add("Fontconfig")
You also have to delete /home/morten/.julia/lib/v0.4/Compose.ji
and restart your REPL session afterwards.
```

I did add a whole macro to the global scope to generate the error message. I feel that it is not ideal but it makes the code more readable (i.e. when compared to a bunch of string interpolations).