### PR TITLE
Fix segfault on draw

### DIFF
--- a/src/container.jl
+++ b/src/container.jl
@@ -427,6 +427,10 @@ end
 
 
 function draw(backend::Backend, root_container::Container)
+	if isfinished(backend)
+		error("The backend has already been drawn upon.")
+	end
+	
     drawpart(backend, root_container, IdentityTransform(), UnitBox(), root_box(backend))
     finish(backend)
 end


### PR DESCRIPTION
Issue #29 crept back in with the addition of container.jl in 87fe13ed1c9b3b1ae493fee02148f26ba4effba9 and removal of canvas.jl in c690d1d05ca4ecbb92dc667b17f38c071adaf159:
 
```shell
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
   _ _   _| |_  __ _   |  Type "?help" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.4.0 (2015-10-08 06:20 UTC)
 _/ |\__'_|_|_|\__'_|  |  
|__/                   |  x86_64-apple-darwin14.5.0

julia> using Compose

julia> foo = compose(context(), circle(0.5, 0.5, 0.25));

julia> bar = PDF("foobar.pdf", 100px, 100px);

julia> draw(bar, foo)

julia> draw(bar, foo)

signal (11): Segmentation fault: 11
```

This tiny PR adds to container.jl the check formerly in canvas.jl that protected against this segfault.