### PR TITLE
make behavior of circle(xs, ys, rs) consistent (#172)

### DIFF
--- a/src/form.jl
+++ b/src/form.jl
@@ -271,7 +271,7 @@ function circle(xs::AbstractArray, ys::AbstractArray, rs::AbstractArray, tag=emp
     end
 
     return @makeform (x in xs, y in ys, r in rs),
-        CirclePrimitive{Vec2, Measure}((x_measure(x), y_measure(y)), size_measure(r)) tag
+        CirclePrimitive{Vec2, Measure}((x_measure(x), y_measure(y)), x_measure(r)) tag
 end
 
 function resolve(box::AbsoluteBox, units::UnitBox, t::Transform,

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -72,3 +72,6 @@ bm = bitmap("fake", rand(UInt8,10), 0, 1, 0.8, 0.7, :image)
 
 @test isa(Compose.line(), Compose.Line)
 @test isa(Compose.line([(1,2),(3,5),(4,2)]), Compose.Line)
+
+# issue #172: default circle(xs, ys, rs) radius measure is context units
+@test isequal(circle([0.5], [0.5], [0.1]).primitives[1].radius, 0.1cx)


### PR DESCRIPTION
This tiny pull request addresses #172: It returns the default measure of `rs` in `circle(xs, ys, rs)` to context units while preserving the ability to call `circle(xs, ys, rs)` with mixed-measure `rs`. Thanks, and best!