### PR TITLE
fixed cairo line drawing when NaN values are present

### DIFF
--- a/src/cairo_backends.jl
+++ b/src/cairo_backends.jl
@@ -862,9 +862,15 @@ end
 
 function draw(img::Image, prim::LinePrimitive)
     if length(prim.points) <= 1; return; end
-    move_to(img, prim.points[1])
-    for i in 2:length(prim.points)
-        line_to(img, prim.points[i])
+    prev_ok = false
+    for (i,p) in enumerate(prim.points)
+        ok = !(isnan(p[1].value) || isnan(p[2].value))
+        if ok && prev_ok
+            line_to(img, p)
+        else
+            move_to(img, p)
+        end
+        prev_ok = ok
     end
     fillstroke(img, true)
 end


### PR DESCRIPTION
This method never checked for NaN values, and so when generating a PNG, there would be line segments flying off the screen at NaN values.  This PR changes the logic to ensure we only call `line_to` when both this point and the previous point are non-NaN.  Otherwise it calls `move_to`.  A bonus is that there's no need for the `move_to` before the loop.  This example (using Plots and OnlineAI) was a mess before (each segment is separated by a NaN value), but now works as expected:

![tmp](https://cloud.githubusercontent.com/assets/933338/13191727/b4a88666-d733-11e5-884c-47160d9bc592.png)
