### PR TITLE
Fix #193, issue with makeform macro in v0.5

### DIFF
--- a/src/fontfallback.jl
+++ b/src/fontfallback.jl
@@ -3,8 +3,11 @@
 # Define this even if we're not calling pango, since cairo needs it.
 const PANGO_SCALE = 1024.0
 
+# Handle deprecation of readall, replacement with readstring
+isdefined(:readstring) || (readstring = readall)
+
 # Serialized glyph sizes for commont fonts.
-const glyphsizes = open(fd -> JSON.parse(readall(fd)),
+const glyphsizes = open(fd -> JSON.parse(readstring(fd)),
                         joinpath(dirname(@__FILE__), "..", "data",
                                  "glyphsize.json"))
 

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -24,15 +24,14 @@ function Maybe(T::Type)
 end
 
 function in_expr_args(ex::Expr)
-    if ex.head === :in
+    ex.head === :in && return ex.args[1], ex.args[2]
+if VERSION < v"0.5.0-dev+3200"
+    (ex.head === :comparison && length(ex.args) == 3 && ex.args[2] === :in) &&
         return ex.args[1], ex.args[2]
-    elseif (ex.head === :comparison && length(ex.args) == 3 &&
-            ex.args[2] === :in)
-        return ex.args[1], ex.args[3]
-    elseif (ex.head === :call && length(ex.args) == 3 &&
-            ex.args[1] === :in)
+else
+    (ex.head === :call && length(ex.args) == 3 && ex.args[1] === :in) &&
         return ex.args[2], ex.args[3]
-    end
+end
     error("Not an `in` expression")
 end
 

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -29,6 +29,9 @@ function in_expr_args(ex::Expr)
     elseif (ex.head === :comparison && length(ex.args) == 3 &&
             ex.args[2] === :in)
         return ex.args[1], ex.args[3]
+    elseif (ex.head === :call && length(ex.args) == 3 &&
+            ex.args[1] === :in)
+        return ex.args[2], ex.args[3]
     end
     error("Not an `in` expression")
 end


### PR DESCRIPTION
The AST that it was inspecting had changed in v0.5 with recent changes, so that it didn't detect the `in` operators correctly.
I also fixed another issue that caused a warning in v0.5 (readall has been deprecated and renamed readstring)