### PR TITLE
Fix problem with HorLineRelPathOp vs HorLineAbsPathOp in svg.jl

### DIFF
--- a/src/svg.jl
+++ b/src/svg.jl
@@ -1020,7 +1020,7 @@ function svg_print_path_op(io::IO, op::LineRelPathOp)
 end
 
 
-function svg_print_path_op(io::IO, op::HorLineRelPathOp)
+function svg_print_path_op(io::IO, op::HorLineAbsPathOp)
     print(io, 'H')
     svg_print_float(io, op.x.value)
 end


### PR DESCRIPTION
This looks like it was a typo, and there must not be any unit test that detects it.
Julia v0.5 gave a warning about the method being overridden, and after inspecting the code,
I saw that the real problem was that two methods both had `HorLineRelPathOp` in the signature,
but the first one (outputting 'H') should have had `HorLineAbsPathOp`.
This is a good example of why the new v0.5 behavior is better than silently ignoring methods being overridden.