### PR TITLE
Fix bug/typo with wrong PathOp for resolve method

### DIFF
--- a/src/form.jl
+++ b/src/form.jl
@@ -1012,8 +1012,8 @@ end
 
 
 function resolve(box::AbsoluteBox, units::UnitBox, t::Transform,
-                 p::QuadCurveRelPathOp)
-    return QuadCurveRelPathOp(
+                 p::QuadCurveShortRelPathOp)
+    return QuadCurveShortRelPathOp(
             (resolve(box, units, t, p.to[1]),
              resolve(box, units, t, p.to[2])))
 end


### PR DESCRIPTION
This is very similar to the other bug in svg.jl that I found, a method was actually overriding an earlier definition, because of the incorrect type being specified on one of the two methods, but this not being detected until v0.5, because of the old policy of silently overriding methods.