### PR TITLE
using UTF8String for SVGClassPrimitive

### DIFF
--- a/src/property.jl
+++ b/src/property.jl
@@ -473,7 +473,7 @@ end
 # --------
 
 immutable SVGClassPrimitive <: PropertyPrimitive
-    value::ASCIIString
+    value::UTF8String
 end
 
 typealias SVGClass Property{SVGClassPrimitive}


### PR DESCRIPTION
using UTF8String for SVGClassPrimitive seems to work with Gadfly and Unicode characters