### PR TITLE
fix for deprecation warnings on 0.5

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.4
 Colors
-Compat 0.8.0
+Compat 0.9.0
 DataStructures
 Iterators 0.1.5
 JSON

--- a/src/pango.jl
+++ b/src/pango.jl
@@ -253,7 +253,7 @@ end
 function unpack_pango_attr(ptr::Ptr{Void}, t::Symbol)
     ptr += sizeof(Ptr{Void}) # skip `klass` pointer
     ptr = convert(Ptr{UInt32}, ptr)
-    idx = pointer_to_array(ptr, (2,))
+    idx = unsafe_wrap(Array, ptr, (2,), false)
     ptr += 2 * sizeof(UInt32)
     ptr = convert(Ptr{Void}, ptr)
 
@@ -278,13 +278,13 @@ end
 #   And int value.
 function unpack_pango_int(ptr::Ptr{Void})
     ptr = convert(Ptr{Int32}, ptr)
-    pointer_to_array(ptr, (1,))[1]
+    unsafe_wrap(Array, ptr, (1,), false)[1]
 end
 
 
 function unpack_pango_float(ptr::Ptr{Void})
     ptr = convert(Ptr{Float64}, ptr)
-    pointer_to_array(ptr, (1,))[1]
+    unsafe_wrap(Array, ptr, (1,), false)[1]
 end
 
 


### PR DESCRIPTION
This fixes some calls to `pointer_to_array`, which was deprecated by https://github.com/JuliaLang/julia/pull/16731